### PR TITLE
Update broadcaster.ts to rxjs v6

### DIFF
--- a/src/broadcaster.ts
+++ b/src/broadcaster.ts
@@ -22,9 +22,7 @@ export class Broadcaster {
       .pipe(
         filter(
           (event) => event.key === key
-        )
-      )
-      .pipe(
+        ),
         map(
           (event) => <T>event.data
         )

--- a/src/broadcaster.ts
+++ b/src/broadcaster.ts
@@ -1,7 +1,5 @@
-import { Subject } from 'rxjs/Subject';
-import { Observable } from 'rxjs/Observable';
-import 'rxjs/add/operator/filter';
-import 'rxjs/add/operator/map';
+import { Subject } from 'rxjs';
+import {map, filter} from 'rxjs/operators';
 
 export interface BroadcastEvent {
   key: any;
@@ -21,7 +19,15 @@ export class Broadcaster {
 
   on<T>(key: any): Observable<T> {
     return this._eventBus.asObservable()
-      .filter(event => event.key === key)
-      .map(event => <T>event.data);
+      .pipe(
+        filter(
+          (event) => event.key === key
+        )
+      )
+      .pipe(
+        map(
+          (event) => <T>event.data
+        )
+      )
   }
 }


### PR DESCRIPTION
'Subject' can now be directly imported from 'rxjs'
'map' and 'filter' can now be imported from 'rxjs/operators'
to use 'filter' and 'map' we must now wrap them to 'pipe' instead of using them directly